### PR TITLE
Upgrade to network-3.1

### DIFF
--- a/Network/Kafka/Protocol.hs
+++ b/Network/Kafka/Protocol.hs
@@ -27,7 +27,7 @@ import Numeric.Lens
 import qualified Data.ByteString.Char8 as B
 import qualified Data.ByteString.Lazy.Char8 as LB (fromStrict, toStrict)
 import qualified Codec.Compression.GZip as GZip (compress, decompress)
-import qualified Network
+import qualified Network.Socket as Network
 
 data ReqResp a where
   MetadataRR :: MonadIO m => MetadataRequest -> ReqResp (m MetadataResponse)
@@ -887,5 +887,5 @@ findPartition p = filtered (view $ partitionId . to (== p))
 hostString :: Lens' Host String
 hostString = hostKString . kString . unpackedChars
 
-portId :: IndexPreservingGetter Port Network.PortID
-portId = portInt . to fromIntegral . to Network.PortNumber
+portNumber :: IndexPreservingGetter Port Network.PortNumber
+portNumber = portInt . to fromIntegral

--- a/milena.cabal
+++ b/milena.cabal
@@ -53,7 +53,7 @@ library
     , monad-control ==1.0.*
     , mtl >=2.1 && <2.3
     , murmur-hash >=0.1.0.8 && <0.2
-    , network >=2.4 && <3.0
+    , network >=2.4 && <3.2
     , random >=1.0 && <1.2
     , resource-pool >=0.2.3.2 && <0.3
     , semigroups >=0.16.2.2 && <0.19

--- a/package.yaml
+++ b/package.yaml
@@ -53,7 +53,7 @@ library:
     - monad-control >=1.0 && <1.1
     - mtl >=2.1 && <2.3
     - murmur-hash >=0.1.0.8 && <0.2
-    - network >=2.4 && <3.0
+    - network >=2.4 && <3.2
     - random >=1.0 && <1.2
     - resource-pool >=0.2.3.2 && <0.3
     - semigroups >=0.16.2.2 && <0.19


### PR DESCRIPTION
The `Network` module had been deprecated for a long time and was replaced by `Network.Socket`. Accordingly, this PR makes necessary changes to the socket connection logic.

The changes are backward compatible and will work on older versions of `network`.